### PR TITLE
Added commons-io dependency

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -90,6 +90,9 @@ grails.project.dependency.resolution = {
      
                 // Better Zip Support
                 'org.apache.commons:commons-compress:1.8',
+                
+                // Better IO Support
+                'commons-io:commons-io:2.4',
 
                 // Easier Java from Joshua Bloch and Google
                 'com.google.guava:guava:14.0',


### PR DESCRIPTION
The absence of Commons-IO breaks the build in Java 8 / Groovy 2.4
