### PR TITLE
Grouping resources with missing resourceId

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -204,7 +204,7 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         }
 
         double resourceCostValue = costValue;
-        if (items.length > resourceIndex && !StringUtils.isEmpty(items[resourceIndex]) && config.resourceService != null) {
+        if (items.length > resourceIndex && config.resourceService != null) {
 
             if (config.useCostForResourceGroup.equals("modeled") && product == Product.ec2_instance)
                 operation = Operation.getReservedInstances(config.reservationService.getDefaultReservationUtilization(0L));


### PR DESCRIPTION
We found that the Breakdown by Resource Groups feature was missing some costs and excluding certain products entirely, such as DynamoDB.  Looking into the detailed AWS billing CSV, it appears as though some rows have an empty string in the ResourceId field.  The Ice processor does not group these resources with missing ResourceId, which skips DynamoDB and other resources.  This pull request removes that extra check for non-empty ResourceId, allowing for these resources to continue to be grouped by resource/product.
