### PR TITLE
Added region property for billing buckets to reference properly if v4…

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -145,6 +145,7 @@ class BootStrap {
 
                 properties.setProperty(IceOptions.LOCAL_DIR, prop.getProperty("ice.processor.localDir"));
                 properties.setProperty(IceOptions.BILLING_S3_BUCKET_NAME, prop.getProperty(IceOptions.BILLING_S3_BUCKET_NAME));
+                properties.setProperty(IceOptions.BILLING_S3_BUCKET_REGION, prop.getProperty(IceOptions.BILLING_S3_BUCKET_REGION));
                 properties.setProperty(IceOptions.BILLING_S3_BUCKET_PREFIX, prop.getProperty(IceOptions.BILLING_S3_BUCKET_PREFIX, ""));
                 properties.setProperty(IceOptions.BILLING_PAYER_ACCOUNT_ID, prop.getProperty(IceOptions.BILLING_PAYER_ACCOUNT_ID, ""));
                 properties.setProperty(IceOptions.BILLING_ACCESS_ROLENAME, prop.getProperty(IceOptions.BILLING_ACCESS_ROLENAME, ""));

--- a/src/java/com/netflix/ice/common/AwsUtils.java
+++ b/src/java/com/netflix/ice/common/AwsUtils.java
@@ -258,8 +258,8 @@ public class AwsUtils {
         }
     }
 
-    public static boolean downloadFileIfChangedSince(String bucketName, String bucketFilePrefix, File file, long milles, String accountId,
-                                                     String assumeRole, String externalId) {
+    public static boolean downloadFileIfChangedSince(String bucketName, String bucketFileRegion, String bucketFilePrefix, File file,
+                                                     long milles, String accountId, String assumeRole, String externalId) {
         AmazonS3Client s3Client = AwsUtils.s3Client;
 
         try {
@@ -270,6 +270,10 @@ public class AwsUtils {
                                 assumedCredentials.getSecretAccessKey(),
                                 assumedCredentials.getSessionToken()),
                                 clientConfig);
+            }
+
+            if(bucketFileRegion != null && !bucketFileRegion.isEmpty()) {
+                s3Client.setEndpoint("s3-" + bucketFileRegion + ".amazonaws.com");
             }
 
             ObjectMetadata metadata = s3Client.getObjectMetadata(bucketName, bucketFilePrefix + file.getName());

--- a/src/java/com/netflix/ice/common/IceOptions.java
+++ b/src/java/com/netflix/ice/common/IceOptions.java
@@ -52,6 +52,12 @@ public class IceOptions {
     public static final String BILLING_S3_BUCKET_NAME = "ice.billing_s3bucketname";
 
     /**
+     * Region for billing s3 bucket. It should be specified for buckets using v4 validation ",".
+     * It must be specified in Config.
+     */
+    public static final String BILLING_S3_BUCKET_REGION = "ice.billing_s3bucketregion";
+
+    /**
      * Prefix of billing files in billing s3 bucket. For multiple payer accounts, multiple bucket prefixes can be specified delimited by comma ",".
      * It must be specified in Config.
      */

--- a/src/java/com/netflix/ice/processor/ProcessorConfig.java
+++ b/src/java/com/netflix/ice/processor/ProcessorConfig.java
@@ -32,6 +32,7 @@ public class ProcessorConfig extends Config {
 
     public final String[] billingAccountIds;
     public final String[] billingS3BucketNames;
+    public final String[] billingS3BucketRegions;
     public final String[] billingS3BucketPrefixes;
     public final String[] billingAccessRoleNames;
     public final String[] billingAccessExternalIds;
@@ -80,6 +81,7 @@ public class ProcessorConfig extends Config {
             this.costPerMonitorMetricPerHour = 0;
 
         billingS3BucketNames = properties.getProperty(IceOptions.BILLING_S3_BUCKET_NAME).split(",");
+        billingS3BucketRegions = properties.getProperty(IceOptions.BILLING_S3_BUCKET_REGION).split(",");
         billingS3BucketPrefixes = properties.getProperty(IceOptions.BILLING_S3_BUCKET_PREFIX, "").split(",");
         billingAccountIds = properties.getProperty(IceOptions.BILLING_PAYER_ACCOUNT_ID, "").split(",");
         billingAccessRoleNames = properties.getProperty(IceOptions.BILLING_ACCESS_ROLENAME, "").split(",");

--- a/src/java/sample.properties
+++ b/src/java/sample.properties
@@ -31,6 +31,8 @@ ice.ondemandCostAlertEmails=
 # modify the following 5 properties according to your billing files configuration. if you have multiple payer accounts, you will need to specify multiple values for each property.
 # s3 bucket name where the billing files are. multiple bucket names are delimited by ",". Ice must have read access to billing s3 bucket.
 ice.billing_s3bucketname=billing_s3bucketname1,billing_s3bucketname2
+# location for the billing bucket.  It should be specified for buckets using v4 validation
+ice.billing_s3bucketregion=eu-west-1,eu-central-1
 # prefix of the billing files. multiple prefixes are delimited by ","
 ice.billing_s3bucketprefix=,
 # specify your payer account id here if across-accounts IAM role access is used. multiple account ids are delimited by ",". "ice.billing_payerAccountId=,222222222222" means assumed role access is only used for the second bucket.


### PR DESCRIPTION
getObjectMetadata call fails with error 400 if v4 auth method is used for access to the s3 objects and region is not specified. This is currently a problem for the billing bucket if it's in, for example, eu-central-1.
