### PR TITLE
Add support for AWS GovCloud region and add missing ap-northeast-2c AZ

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -145,6 +145,12 @@ public class BasicReservationService extends Poller implements ReservationServic
         AmazonEC2Client ec2Client = new AmazonEC2Client(AwsUtils.awsCredentialsProvider, AwsUtils.clientConfig);
 
         for (Region region: Region.getAllRegions()) {
+            // GovCloud uses different credentials than standard AWS, so you would need two separate
+            // sets of credentials if you wanted to poll for RIs in both environments. For now, we
+            // just ignore GovCloud here in order to prevent AuthFailure errors.
+            if (region == Region.US_GOV_WEST_1) {
+                continue;
+            }
             ec2Client.setEndpoint("ec2." + region.name + ".amazonaws.com");
             do {
                 if (!StringUtils.isEmpty(token))

--- a/src/java/com/netflix/ice/processor/ReservationCapacityPoller.java
+++ b/src/java/com/netflix/ice/processor/ReservationCapacityPoller.java
@@ -139,6 +139,12 @@ public class ReservationCapacityPoller extends Poller {
                     ec2Client = new AmazonEC2Client(AwsUtils.awsCredentialsProvider.getCredentials(), AwsUtils.clientConfig);
 
                 for (Region region: Region.getAllRegions()) {
+                    // GovCloud uses different credentials than standard AWS, so you would need two separate
+                    // sets of credentials if you wanted to poll for RIs in both environments. For now, we
+                    // just ignore GovCloud when polling for RIs in order to prevent AuthFailure errors.
+                    if (region == Region.US_GOV_WEST_1) {
+                        continue;
+                    }
 
                     ec2Client.setEndpoint("ec2." + region.name + ".amazonaws.com");
 

--- a/src/java/com/netflix/ice/tag/Region.java
+++ b/src/java/com/netflix/ice/tag/Region.java
@@ -29,6 +29,7 @@ public class Region extends Tag {
     public static final Region US_EAST_2 = new Region("us-east-2", "USE2");
     public static final Region US_WEST_1 = new Region("us-west-1", "USW1");
     public static final Region US_WEST_2 = new Region("us-west-2", "USW2");
+    public static final Region US_GOV_WEST_1 = new Region("us-gov-west-1", "UGW1");
     public static final Region EU_WEST_1 = new Region("eu-west-1", "EU");
     public static final Region EU_WEST_2 = new Region("eu-west-2", "EUW2");
     public static final Region EU_CENTRAL_1 = new Region("eu-central-1", "EUC1");
@@ -48,6 +49,7 @@ public class Region extends Tag {
         regionsByShortName.put(US_EAST_2.shortName, US_EAST_2);
         regionsByShortName.put(US_WEST_1.shortName, US_WEST_1);
         regionsByShortName.put(US_WEST_2.shortName, US_WEST_2);
+        regionsByShortName.put(US_GOV_WEST_1.shortName, US_GOV_WEST_1);
         regionsByShortName.put(EU_WEST_1.shortName, EU_WEST_1);
         regionsByShortName.put(EU_WEST_2.shortName, EU_WEST_2);
         regionsByShortName.put(EU_CENTRAL_1.shortName, EU_CENTRAL_1);
@@ -63,6 +65,7 @@ public class Region extends Tag {
         regionsByName.put(US_EAST_2.name, US_EAST_2);
         regionsByName.put(US_WEST_1.name, US_WEST_1);
         regionsByName.put(US_WEST_2.name, US_WEST_2);
+        regionsByName.put(US_GOV_WEST_1.name, US_GOV_WEST_1);
         regionsByName.put(EU_WEST_1.name, EU_WEST_1);
         regionsByName.put(EU_WEST_2.name, EU_WEST_2);
         regionsByName.put(EU_CENTRAL_1.name, EU_CENTRAL_1);

--- a/src/java/com/netflix/ice/tag/Zone.java
+++ b/src/java/com/netflix/ice/tag/Zone.java
@@ -52,6 +52,9 @@ public class Zone extends Tag {
     public static final Zone US_WEST_2B = new Zone(Region.US_WEST_2, "us-west-2b");
     public static final Zone US_WEST_2C = new Zone(Region.US_WEST_2, "us-west-2c");
 
+    public static final Zone US_GOV_WEST_1A = new Zone(Region.US_GOV_WEST_1, "us-gov-west-1a");
+    public static final Zone US_GOV_WEST_1B = new Zone(Region.US_GOV_WEST_1, "us-gov-west-1b");
+
     public static final Zone EU_WEST_1A = new Zone(Region.EU_WEST_1, "eu-west-1a");
     public static final Zone EU_WEST_1B = new Zone(Region.EU_WEST_1, "eu-west-1b");
     public static final Zone EU_WEST_1C = new Zone(Region.EU_WEST_1, "eu-west-1c");
@@ -72,6 +75,7 @@ public class Zone extends Tag {
 
     public static final Zone AP_NORTHEAST_2A = new Zone(Region.AP_NORTHEAST_2, "ap-northeast-2a");
     public static final Zone AP_NORTHEAST_2B = new Zone(Region.AP_NORTHEAST_2, "ap-northeast-2b");
+    public static final Zone AP_NORTHEAST_2C = new Zone(Region.AP_NORTHEAST_2, "ap-northeast-2c");
 
     public static final Zone AP_SOUTHEAST_1A = new Zone(Region.AP_SOUTHEAST_1, "ap-southeast-1a");
     public static final Zone AP_SOUTHEAST_1B = new Zone(Region.AP_SOUTHEAST_1, "ap-southeast-1b");
@@ -108,6 +112,9 @@ public class Zone extends Tag {
         zonesByName.put(US_WEST_2B.name, US_WEST_2B);
         zonesByName.put(US_WEST_2C.name, US_WEST_2C);
 
+        zonesByName.put(US_GOV_WEST_1A.name, US_GOV_WEST_1A);
+        zonesByName.put(US_GOV_WEST_1B.name, US_GOV_WEST_1B);
+
         zonesByName.put(EU_WEST_1A.name, EU_WEST_1A);
         zonesByName.put(EU_WEST_1B.name, EU_WEST_1B);
         zonesByName.put(EU_WEST_1C.name, EU_WEST_1C);
@@ -128,6 +135,7 @@ public class Zone extends Tag {
 
         zonesByName.put(AP_NORTHEAST_2A.name, AP_NORTHEAST_2A);
         zonesByName.put(AP_NORTHEAST_2B.name, AP_NORTHEAST_2B);
+        zonesByName.put(AP_NORTHEAST_2C.name, AP_NORTHEAST_2C);
 
         zonesByName.put(AP_SOUTHEAST_1A.name, AP_SOUTHEAST_1A);
         zonesByName.put(AP_SOUTHEAST_1B.name, AP_SOUTHEAST_1B);


### PR DESCRIPTION
This PR adds support for the AWS GovCloud region and adds the `ap-northeast-2c` AZ (which was missing).

GovCloud uses completely separate credentials from standard AWS, so the reservation capacity / utilization pollers will not be able to access it. GovCloud accounts are associated with standard AWS accounts for billing purposes: their usage appears as line items in a standard AWS account's bill and thus can show up in ICE reports, so it's necessary to add this region in order to be able to properly group costs by region.

See https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/usage-and-payment.html for more details on GovCloud billing and payment.