### PR TITLE
Allow extra configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ Options with * require writing your own code.
 
         ice.use_blended=true
 
+10. Extra Grails configuration file
+
+  If you need to setup custom Grails settings, you can specify an additional configuration file to be loaded by Grails by setting the ``ice.config.location`` system property to the location of that file.
+
+  See http://docs.grails.org/2.3.7/guide/single.html#configExternalized for more information.
+
 ## Example IAM Permissions
 
 Grant the following permissions to either an instance role, or the user running the reports:

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Options with * require writing your own code.
 
   If you need to setup custom Grails settings, you can specify an additional configuration file to be loaded by Grails by setting the ``ice.config.location`` system property to the location of that file.
 
-  See http://docs.grails.org/2.3.7/guide/single.html#configExternalized for more information.
+  See http://docs.grails.org/2.4.4/guide/single.html#configExternalized for more information.
 
 ## Example IAM Permissions
 

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -17,13 +17,11 @@
 // locations to search for config files that get merged into the main config
 // config files can either be Java properties files or ConfigSlurper scripts
 
-grails.config.locations = [
+grails.config.locations = []
 
-]
-
-// if(System.properties["${appName}.config.location"]) {
-//    grails.config.locations << "file:" + System.properties["${appName}.config.location"]
-// }
+if(System.properties["${appName}.config.location"]) {
+    grails.config.locations << "file:" + System.properties["${appName}.config.location"]
+}
 
 grails.project.groupId = appName // change this to alter the default package name and Maven publishing destination
 grails.mime.file.extensions = true // enables the parsing of file extensions from URLs into the request format


### PR DESCRIPTION
In order to override some configuration settings, we can now specify an
additional configuration location using the Java system properties
``ice.config.location`` which points to another configuration file
location.

Otherwise, the only way to set custom configuration parameters is by
overriding this while Config.groovy file.